### PR TITLE
refactor: Convert lambda declarations to function declarations

### DIFF
--- a/src/components/ChallengeModal/ForkModal.tsx
+++ b/src/components/ChallengeModal/ForkModal.tsx
@@ -29,7 +29,7 @@ interface ForkModalProperties {
     goban: GobanRenderer;
 }
 
-export const ForkModal = ({ goban }: ForkModalProperties) => {
+export function ForkModal({ goban }: ForkModalProperties): React.ReactElement {
     const [currPlayer, setCurrPlayer] = React.useState(null as PlayerCacheEntry | null);
     const { hideModal } = React.useContext(ModalContext);
 
@@ -83,4 +83,4 @@ export const ForkModal = ({ goban }: ForkModalProperties) => {
             </div>
         </div>
     );
-};
+}

--- a/src/components/LanguagePicker/LanguagePicker.tsx
+++ b/src/components/LanguagePicker/LanguagePicker.tsx
@@ -36,7 +36,7 @@ function language_sorter(a: string, b: string) {
     return 0;
 }
 
-export const LanguagePicker = () => {
+export function LanguagePicker(): React.ReactElement {
     const { showModal } = React.useContext(ModalContext);
 
     return (
@@ -48,9 +48,9 @@ export const LanguagePicker = () => {
             {languages[current_language]}
         </span>
     );
-};
+}
 
-export const LanguagePickerModal = () => {
+export function LanguagePickerModal(): React.ReactElement {
     const { hideModal } = React.useContext(ModalContext);
 
     const setLanguage = (language_code: string) => {
@@ -96,4 +96,4 @@ export const LanguagePickerModal = () => {
             </div>
         </div>
     );
-};
+}

--- a/src/components/ModalProvider/ModalProvider.tsx
+++ b/src/components/ModalProvider/ModalProvider.tsx
@@ -33,7 +33,7 @@ type ModalTypesProps = {
     [key: string]: any;
 };
 
-export const ModalProvider = ({ children }: React.PropsWithChildren): React.ReactElement => {
+export function ModalProvider({ children }: React.PropsWithChildren): React.ReactElement {
     const [modalType, setModalType] = React.useState(null as ModalTypes | null);
     const [modalProps, setModalProps] = React.useState({} as ModalTypesProps);
 
@@ -93,4 +93,4 @@ export const ModalProvider = ({ children }: React.PropsWithChildren): React.Reac
             {children}
         </ModalContext.Provider>
     );
-};
+}

--- a/src/components/ModalProvider/ModalRegistry.ts
+++ b/src/components/ModalProvider/ModalRegistry.ts
@@ -30,10 +30,10 @@ export const modalRegistry: ModalRegistry = {
     [ModalTypes.GameLog]: GameLogModal,
 };
 
-export const registerModal = (modalType: string, component: React.ComponentType<any>) => {
+export function registerModal(modalType: string, component: React.ComponentType<any>): void {
     modalRegistry[modalType] = component;
-};
+}
 
-export const unregisterModal = (modalType: string) => {
+export function unregisterModal(modalType: string): void {
     delete modalRegistry[modalType];
-};
+}

--- a/src/components/Steps/Steps.tsx
+++ b/src/components/Steps/Steps.tsx
@@ -29,7 +29,7 @@ interface StepsProperties {
     // callback?: ()=>any,
 }
 
-export const Steps = (props: StepsProperties) => {
+export function Steps(props: StepsProperties): React.ReactElement {
     const children = (
         Array.isArray(props.children) ? props.children : props.children ? [props.children] : []
     ).concat([]);
@@ -82,4 +82,4 @@ export const Steps = (props: StepsProperties) => {
             })}
         </div>
     );
-};
+}

--- a/src/components/material/material.tsx
+++ b/src/components/material/material.tsx
@@ -18,63 +18,73 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
-export const Card = (props: React.HTMLProps<HTMLDivElement>) => (
-    <div {...props} className={"Card " + (props.className || "")}>
-        {props.children}
-    </div>
-);
+export function Card(props: React.HTMLProps<HTMLDivElement>): React.ReactElement {
+    return (
+        <div {...props} className={"Card " + (props.className || "")}>
+            {props.children}
+        </div>
+    );
+}
 
-export const CardLink = (props: any) => (
-    <Link {...props} className={"Card " + (props.className || "")}>
-        {props.children}
-    </Link>
-);
+export function CardLink(props: any): React.ReactElement {
+    return (
+        <Link {...props} className={"Card " + (props.className || "")}>
+            {props.children}
+        </Link>
+    );
+}
 
-export const FabCheck = (props: React.HTMLProps<HTMLDivElement>) => (
-    <div {...props} className="fab primary raiser">
-        <svg
-            viewBox="0 0 24 24"
-            height="100%"
-            width="100%"
-            preserveAspectRatio="xMidYMid meet"
-            style={{ pointerEvents: "none", display: "block" }}
-        >
-            <g>
-                <polygon points="9,16.2 4.8,12 3.4,13.4 9,19 21,7 19.6,5.6 "></polygon>
-            </g>
-        </svg>
-    </div>
-);
+export function FabCheck(props: React.HTMLProps<HTMLDivElement>): React.ReactElement {
+    return (
+        <div {...props} className="fab primary raiser">
+            <svg
+                viewBox="0 0 24 24"
+                height="100%"
+                width="100%"
+                preserveAspectRatio="xMidYMid meet"
+                style={{ pointerEvents: "none", display: "block" }}
+            >
+                <g>
+                    <polygon points="9,16.2 4.8,12 3.4,13.4 9,19 21,7 19.6,5.6 "></polygon>
+                </g>
+            </svg>
+        </div>
+    );
+}
 
-export const FabX = (props: React.HTMLProps<HTMLDivElement>) => (
-    <div {...props} className="fab reject raiser">
-        <svg
-            viewBox="0 0 24 24"
-            height="100%"
-            width="100%"
-            preserveAspectRatio="xMidYMid meet"
-            style={{ pointerEvents: "none", display: "block" }}
-        >
-            <g>
-                <polygon points="19,6.4 17.6,5 12,10.6 6.4,5 5,6.4 10.6,12 5,17.6 6.4,19 12,13.4 17.6,19 19,17.6 13.4,12"></polygon>
-            </g>
-        </svg>
-    </div>
-);
+export function FabX(props: React.HTMLProps<HTMLDivElement>): React.ReactElement {
+    return (
+        <div {...props} className="fab reject raiser">
+            <svg
+                viewBox="0 0 24 24"
+                height="100%"
+                width="100%"
+                preserveAspectRatio="xMidYMid meet"
+                style={{ pointerEvents: "none", display: "block" }}
+            >
+                <g>
+                    <polygon points="19,6.4 17.6,5 12,10.6 6.4,5 5,6.4 10.6,12 5,17.6 6.4,19 12,13.4 17.6,19 19,17.6 13.4,12"></polygon>
+                </g>
+            </svg>
+        </div>
+    );
+}
 
-export const FabAdd = (props: React.HTMLProps<HTMLDivElement>) => (
-    <div {...props} className="fab info raiser">
-        <svg
-            viewBox="0 0 24 24"
-            height="100%"
-            width="100%"
-            preserveAspectRatio="xMidYMid meet"
-            style={{ pointerEvents: "none", display: "block" }}
-        >
-            <path d="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6V13z" />
-        </svg>
-    </div>
-);
+export function FabAdd(props: React.HTMLProps<HTMLDivElement>): React.ReactElement {
+    return (
+        <div {...props} className="fab info raiser">
+            <svg
+                viewBox="0 0 24 24"
+                height="100%"
+                width="100%"
+                preserveAspectRatio="xMidYMid meet"
+                style={{ pointerEvents: "none", display: "block" }}
+            >
+                <path d="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6V13z" />
+            </svg>
+        </div>
+    );
+}
 
 export default {
     Card: Card,

--- a/src/components/misc-ui/misc-ui.tsx
+++ b/src/components/misc-ui/misc-ui.tsx
@@ -21,25 +21,31 @@ import React from "react";
  *   --- my text ---
  * It relies on css for 'left' and 'right' being as expected in context, caveat emptor. */
 
-export const LineText = (props: React.HTMLProps<HTMLDivElement>) => (
-    <div {...props} className={"LineText " + (props.className || "")}>
-        <span className="left" />
-        <span className="contents">{props.children}</span>
-        <span className="right" />
-    </div>
-);
-
-export const SearchInput = (props: React.HTMLProps<HTMLInputElement>) => (
-    <div className={"SearchInput " + (props.className || "")}>
-        <i className="fa fa-search"></i>
-        <input type="search" className={props.className || ""} {...props} />
-    </div>
-);
-
-export const Ribbon = (props: React.HTMLProps<HTMLDivElement>) => (
-    <div className="Ribbon-container">
-        <div {...props} className={"Ribbon " + (props.className || "")}>
-            {props.children}
+export function LineText(props: React.HTMLProps<HTMLDivElement>): React.ReactElement {
+    return (
+        <div {...props} className={"LineText " + (props.className || "")}>
+            <span className="left" />
+            <span className="contents">{props.children}</span>
+            <span className="right" />
         </div>
-    </div>
-);
+    );
+}
+
+export function SearchInput(props: React.HTMLProps<HTMLInputElement>): React.ReactElement {
+    return (
+        <div className={"SearchInput " + (props.className || "")}>
+            <i className="fa fa-search"></i>
+            <input type="search" className={props.className || ""} {...props} />
+        </div>
+    );
+}
+
+export function Ribbon(props: React.HTMLProps<HTMLDivElement>): React.ReactElement {
+    return (
+        <div className="Ribbon-container">
+            <div {...props} className={"Ribbon " + (props.className || "")}>
+                {props.children}
+            </div>
+        </div>
+    );
+}

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -70,7 +70,7 @@ export function useMainGoban(): Goban | null | undefined {
     return window.global_goban;
 }
 
-export const useIsDesktop = () => {
+export function useIsDesktop(): boolean {
     const [isDesktop, setIsDesktop] = React.useState(true);
 
     React.useEffect(() => {
@@ -84,4 +84,4 @@ export const useIsDesktop = () => {
     }, []);
 
     return isDesktop;
-};
+}

--- a/src/views/GoTV/GoTV.tsx
+++ b/src/views/GoTV/GoTV.tsx
@@ -46,7 +46,7 @@ const load_twitch_library = () => {
 };
 
 // GoTV component manages the live stream display and user interactions
-export const GoTV = () => {
+export function GoTV(): React.ReactElement {
     const [isMobile, setIsMobile] = useState(window.innerWidth <= 900);
     const [streams, setStreams] = useState<Stream[]>([]);
     const [selectedStream, setSelectedStream] = useState<Stream | null>(null);
@@ -277,7 +277,7 @@ export const GoTV = () => {
             </div>
         </div>
     );
-};
+}
 
 const getParentDomain = () => {
     return window.location.hostname;

--- a/src/views/GoTV/GoTVIndicator.tsx
+++ b/src/views/GoTV/GoTVIndicator.tsx
@@ -22,7 +22,7 @@ import { Stream, streamManager } from "./StreamManager";
 import { GoTVNotifier } from "./GoTVNotifier";
 
 // GoTVIndicator component shows the number of live streams and a link to GoTV
-export const GoTVIndicator: React.FC = () => {
+export function GoTVIndicator(): React.ReactElement {
     const [streams, setStreams] = useState<Stream[]>([]);
     const [streamCount, setStreamCount] = useState(0);
     const [showGoTVIndicator] = preferences.usePreference("gotv.show-gotv-indicator");
@@ -86,4 +86,4 @@ export const GoTVIndicator: React.FC = () => {
             <GoTVNotifier streams={streams} />
         </>
     );
-};
+}

--- a/src/views/GoTV/GoTVNotifier.tsx
+++ b/src/views/GoTV/GoTVNotifier.tsx
@@ -38,7 +38,7 @@ const NOTIFICATION_EXPIRATION_HOURS = 12;
 const NOTIFICATION_EXPIRATION_MS = NOTIFICATION_EXPIRATION_HOURS * 60 * 60 * 1000;
 
 // GoTVNotifier component manages notifications for live streams
-export const GoTVNotifier: React.FC<GoTVNotifierProps> = ({ streams }) => {
+export function GoTVNotifier({ streams }: GoTVNotifierProps): React.ReactElement {
     const [notifications, setNotifications] = useState<Notification[]>([]);
     const [allowNotifications] = usePreference("gotv.allow-notifications");
     const [followedChannels] = usePreference("gotv.followed-channels");
@@ -180,4 +180,4 @@ export const GoTVNotifier: React.FC<GoTVNotifierProps> = ({ streams }) => {
             )}
         </div>
     );
-};
+}

--- a/src/views/GoTV/StreamCard.tsx
+++ b/src/views/GoTV/StreamCard.tsx
@@ -34,7 +34,7 @@ interface StreamCardProps {
 }
 
 // StreamCard component displays information about a live stream
-export const StreamCard: React.FC<StreamCardProps> = ({ stream, isSelected, onClick }) => {
+export function StreamCard({ stream, isSelected, onClick }: StreamCardProps): React.ReactElement {
     return (
         <div
             // Apply "selected-stream" class if this stream is selected
@@ -58,4 +58,4 @@ export const StreamCard: React.FC<StreamCardProps> = ({ stream, isSelected, onCl
             <div className="full-title">{stream.title}</div>
         </div>
     );
-};
+}

--- a/src/views/Prizes/PrizeBatch.tsx
+++ b/src/views/Prizes/PrizeBatch.tsx
@@ -34,7 +34,7 @@ interface PrizeBatchParams {
     id: string;
 }
 
-export const PrizeBatch: React.FC = () => {
+export function PrizeBatch(): React.ReactElement {
     const params = useParams<keyof PrizeBatchParams>();
     const [batch, setBatch] = useState<PrizeBatch>();
     const [qty, setQty] = useState(1);
@@ -400,4 +400,4 @@ export const PrizeBatch: React.FC = () => {
             )}
         </div>
     );
-};
+}

--- a/src/views/Prizes/PrizeBatchList.tsx
+++ b/src/views/Prizes/PrizeBatchList.tsx
@@ -29,7 +29,7 @@ interface PrizeBatch {
     notes: string;
 }
 
-export const PrizeBatchList: React.FC = () => {
+export function PrizeBatchList(): React.ReactElement {
     const [prizeBatches, setPrizeBatches] = useState<PrizeBatch[]>([]);
     const [showNewBatchForm, setShowNewBatchForm] = useState<boolean>(false);
     const [expirationDate, setExpirationDate] = useState<string>(calculateExpirationDate());
@@ -119,7 +119,7 @@ export const PrizeBatchList: React.FC = () => {
             )}
         </div>
     );
-};
+}
 
 const NewBatchForm: React.FC<{
     expirationDate: string;

--- a/src/views/Prizes/PrizeRedemption.tsx
+++ b/src/views/Prizes/PrizeRedemption.tsx
@@ -31,7 +31,7 @@ interface Prize {
     supporter_level: string;
 }
 
-export const PrizeRedemption: React.FC = () => {
+export function PrizeRedemption(): React.ReactElement {
     const [code, setCode] = useState(["", "", "", "", "", ""]);
     const [prizeInfo, setPrizeInfo] = useState<Prize>();
     const [showForm, setShowForm] = useState(true);
@@ -278,4 +278,4 @@ export const PrizeRedemption: React.FC = () => {
             )}
         </div>
     );
-};
+}

--- a/src/views/User/UserVoteActionSummary.tsx
+++ b/src/views/User/UserVoteActionSummary.tsx
@@ -33,7 +33,7 @@ interface VoteSummaryPieProps {
     summary_data: VoteSummaryData;
 }
 
-export const VoteSummaryPie = ({ summary_data }: VoteSummaryPieProps) => {
+export function VoteSummaryPie({ summary_data }: VoteSummaryPieProps): React.ReactElement {
     const chart_data = React.useMemo(
         () => [
             { id: "consensus", value: summary_data["total_consensus"] },
@@ -73,14 +73,17 @@ export const VoteSummaryPie = ({ summary_data }: VoteSummaryPieProps) => {
             />
         </div>
     );
-};
+}
 
 interface UserVoteActionSummaryProps {
     user_id: number;
     report_type?: ReportType;
 }
 
-export const UserVoteActionSummary = ({ user_id, report_type }: UserVoteActionSummaryProps) => {
+export function UserVoteActionSummary({
+    user_id,
+    report_type,
+}: UserVoteActionSummaryProps): React.ReactElement {
     const [summary_data, setSummaryData] = useState<VoteSummaryData | null>(null);
 
     // Data fetch
@@ -105,4 +108,4 @@ export const UserVoteActionSummary = ({ user_id, report_type }: UserVoteActionSu
         return <div>Loading...</div>;
     }
     return <VoteSummaryPie summary_data={summary_data} />;
-};
+}

--- a/src/views/User/VoteActivityGraph.tsx
+++ b/src/views/User/VoteActivityGraph.tsx
@@ -142,7 +142,7 @@ interface UserVoteActivityGraphProps {
     user_id: number;
 }
 
-export const UserVoteActivityGraph = ({ user_id }: UserVoteActivityGraphProps) => {
+export function UserVoteActivityGraph({ user_id }: UserVoteActivityGraphProps): React.ReactElement {
     const [vote_data, setVoteData] = useState<ModeratorVoteCountData | null>(null);
 
     // Data fetch
@@ -162,4 +162,4 @@ export const UserVoteActivityGraph = ({ user_id }: UserVoteActivityGraphProps) =
         return <div>Loading...</div>;
     }
     return <VoteActivityGraph vote_data={vote_data} />;
-};
+}

--- a/src/views/docs/GoResources.tsx
+++ b/src/views/docs/GoResources.tsx
@@ -62,7 +62,7 @@ function ordered(...args: React.ReactElement[]) {
     });
 }
 
-export const GoResources = () => {
+export function GoResources(): React.ReactElement {
     window.document.title = _("Other Go Resources");
 
     const country = data.get("user")?.country || "us";
@@ -1681,7 +1681,7 @@ export const GoResources = () => {
             </div>
         </div>
     );
-};
+}
 
 interface BasicResourceProps {
     countries: string[];

--- a/src/views/docs/RulesMatrix.tsx
+++ b/src/views/docs/RulesMatrix.tsx
@@ -17,151 +17,156 @@
 
 import * as React from "react";
 
-export const RulesMatrix = () => (
-    <div id="RulesMatrix">
-        <div id="docs-go-rules-comparison-matrix">
-            <table className="rules">
-                <tr>
-                    <th></th>
-                    <th>AGA</th>
-                    <th>Japanese (JP)</th>
-                    <th>Chinese (CN)</th>
-                    <th>Korean (KR)</th>
-                    <th>Ing's SST Rules (Ing)</th>
-                    <th>New Zealand (NZ)</th>
-                </tr>
+export function RulesMatrix(): React.ReactElement {
+    return (
+        <div id="RulesMatrix">
+            <div id="docs-go-rules-comparison-matrix">
+                <table className="rules">
+                    <tbody>
+                        <tr>
+                            <th></th>
+                            <th>AGA</th>
+                            <th>Japanese (JP)</th>
+                            <th>Chinese (CN)</th>
+                            <th>Korean (KR)</th>
+                            <th>Ing's SST Rules (Ing)</th>
+                            <th>New Zealand (NZ)</th>
+                        </tr>
 
-                <tr>
-                    <th>Komi</th>
-                    <td>7.5</td>
-                    <td>6.5</td>
-                    <td>7.5 (Scored as 3.75 is removed from Black and given to White)</td>
-                    <td>6.5</td>
-                    <td>8</td>
-                    <td>7</td>
-                </tr>
+                        <tr>
+                            <th>Komi</th>
+                            <td>7.5</td>
+                            <td>6.5</td>
+                            <td>7.5 (Scored as 3.75 is removed from Black and given to White)</td>
+                            <td>6.5</td>
+                            <td>8</td>
+                            <td>7</td>
+                        </tr>
 
-                <tr>
-                    <th>Handicap Positioning</th>
-                    <td>Fixed Points</td>
-                    <td>Fixed Points</td>
-                    <td>Free Placement</td>
-                    <td>Fixed Points</td>
-                    <td>Free Placement</td>
-                    <td>Free Placement</td>
-                </tr>
+                        <tr>
+                            <th>Handicap Positioning</th>
+                            <td>Fixed Points</td>
+                            <td>Fixed Points</td>
+                            <td>Free Placement</td>
+                            <td>Fixed Points</td>
+                            <td>Free Placement</td>
+                            <td>Free Placement</td>
+                        </tr>
 
-                <tr>
-                    <th>Handicap Score Adjustment</th>
-                    <td>
-                        When Area scoring is in effect, White receives an additional point of
-                        compensation for each black Handicap stone after the first.
-                    </td>
-                    <td>None</td>
-                    <td>
-                        White receives an additional point of compensation for each black Handicap
-                        stone.
-                    </td>
-                    <td>None</td>
-                    <td>
-                        White receives an additional point of compensation for each black Handicap
-                        stone.
-                    </td>
-                    <td>None</td>
-                </tr>
-                <tr>
-                    <th>Special rules when Passing</th>
-                    <td>Opponent receives one Prisoner on Pass</td>
-                    <td>None</td>
-                    <td>None</td>
-                    <td>None</td>
-                    <td>None</td>
-                    <td>None</td>
-                </tr>
-                <tr>
-                    <th>Self Capture</th>
-                    <td>No</td>
-                    <td>No</td>
-                    <td>No</td>
-                    <td>No</td>
-                    <td>Yes</td>
-                    <td>Yes</td>
-                </tr>
-                <tr>
-                    <th>Super-Ko</th>
-                    <td>Repetitions are forbidden</td>
-                    <td>
-                        Board repetition is allowed, if neither side is willing to break the loop
-                        the game is annulled
-                    </td>
-                    <td>Repetitions are forbidden</td>
-                    <td>
-                        Board repetition is allowed, if neither side is willing to break the loop
-                        the game is annulled
-                    </td>
-                    <td>Forces avoidance of repetition through special SST Ko Rule</td>
-                    <td>Repetitions are forbidden</td>
-                </tr>
-                <tr>
-                    <th>Ending the Game</th>
-                    <td>
-                        Either two or three consecutive passes, with White being the last to pass.
-                    </td>
-                    <td>Two passes</td>
-                    <td>Two passes</td>
-                    <td>Two passes</td>
-                    <td>Two passes</td>
-                    <td>Two passes</td>
-                </tr>
-                <tr>
-                    <th>Stone removal phase</th>
-                    <td>Dead stones mutually agreed upon.</td>
-                    <td>Subject to special Japanese stone removal rules</td>
-                    <td>Dead stones mutually agreed upon.</td>
-                    <td>Subject to special Korean stone removal rules</td>
-                    <td>Dead stones mutually agreed upon.</td>
-                    <td>Dead stones mutually agreed upon.</td>
-                </tr>
-                <tr>
-                    <th>Dame filling during stone removal</th>
-                    <td>No</td>
-                    <td>Yes, placements must be agreed upon</td>
-                    <td>No</td>
-                    <td>Yes, placements must be agreed upon</td>
-                    <td>Yes, alternating placements.</td>
-                    <td>No</td>
-                </tr>
-                <tr>
-                    <th>Dame negates territory of adjacent strings</th>
-                    <td>No</td>
-                    <td>Yes</td>
-                    <td>No</td>
-                    <td>Yes</td>
-                    <td>No</td>
-                    <td>No</td>
-                </tr>
-                <tr>
-                    <th>Player to play after resuming from the Stone Removal Phase</th>
-                    <td>Opponent of the last to pass</td>
-                    <td>Opponent of the player to resume the game</td>
-                    <td>Opponent of the last to pass</td>
-                    <td>Opponent of the player to resume the game</td>
-                    <td>Opponent of the last to pass</td>
-                    <td>Opponent of the last to pass</td>
-                </tr>
-                <tr>
-                    <th>Scoring</th>
-                    <td>
-                        Area <strong>or</strong> Territory minus prisoners (Resulting winner is
-                        always the same in either case)
-                    </td>
-                    <td>Territory minus prisoners</td>
-                    <td>Area</td>
-                    <td>Territory minus prisoners</td>
-                    <td>Area</td>
-                    <td>Area</td>
-                </tr>
-            </table>
+                        <tr>
+                            <th>Handicap Score Adjustment</th>
+                            <td>
+                                When Area scoring is in effect, White receives an additional point
+                                of compensation for each black Handicap stone after the first.
+                            </td>
+                            <td>None</td>
+                            <td>
+                                White receives an additional point of compensation for each black
+                                Handicap stone.
+                            </td>
+                            <td>None</td>
+                            <td>
+                                White receives an additional point of compensation for each black
+                                Handicap stone.
+                            </td>
+                            <td>None</td>
+                        </tr>
+                        <tr>
+                            <th>Special rules when Passing</th>
+                            <td>Opponent receives one Prisoner on Pass</td>
+                            <td>None</td>
+                            <td>None</td>
+                            <td>None</td>
+                            <td>None</td>
+                            <td>None</td>
+                        </tr>
+                        <tr>
+                            <th>Self Capture</th>
+                            <td>No</td>
+                            <td>No</td>
+                            <td>No</td>
+                            <td>No</td>
+                            <td>Yes</td>
+                            <td>Yes</td>
+                        </tr>
+                        <tr>
+                            <th>Super-Ko</th>
+                            <td>Repetitions are forbidden</td>
+                            <td>
+                                Board repetition is allowed, if neither side is willing to break the
+                                loop the game is annulled
+                            </td>
+                            <td>Repetitions are forbidden</td>
+                            <td>
+                                Board repetition is allowed, if neither side is willing to break the
+                                loop the game is annulled
+                            </td>
+                            <td>Forces avoidance of repetition through special SST Ko Rule</td>
+                            <td>Repetitions are forbidden</td>
+                        </tr>
+                        <tr>
+                            <th>Ending the Game</th>
+                            <td>
+                                Either two or three consecutive passes, with White being the last to
+                                pass.
+                            </td>
+                            <td>Two passes</td>
+                            <td>Two passes</td>
+                            <td>Two passes</td>
+                            <td>Two passes</td>
+                            <td>Two passes</td>
+                        </tr>
+                        <tr>
+                            <th>Stone removal phase</th>
+                            <td>Dead stones mutually agreed upon.</td>
+                            <td>Subject to special Japanese stone removal rules</td>
+                            <td>Dead stones mutually agreed upon.</td>
+                            <td>Subject to special Korean stone removal rules</td>
+                            <td>Dead stones mutually agreed upon.</td>
+                            <td>Dead stones mutually agreed upon.</td>
+                        </tr>
+                        <tr>
+                            <th>Dame filling during stone removal</th>
+                            <td>No</td>
+                            <td>Yes, placements must be agreed upon</td>
+                            <td>No</td>
+                            <td>Yes, placements must be agreed upon</td>
+                            <td>Yes, alternating placements.</td>
+                            <td>No</td>
+                        </tr>
+                        <tr>
+                            <th>Dame negates territory of adjacent strings</th>
+                            <td>No</td>
+                            <td>Yes</td>
+                            <td>No</td>
+                            <td>Yes</td>
+                            <td>No</td>
+                            <td>No</td>
+                        </tr>
+                        <tr>
+                            <th>Player to play after resuming from the Stone Removal Phase</th>
+                            <td>Opponent of the last to pass</td>
+                            <td>Opponent of the player to resume the game</td>
+                            <td>Opponent of the last to pass</td>
+                            <td>Opponent of the player to resume the game</td>
+                            <td>Opponent of the last to pass</td>
+                            <td>Opponent of the last to pass</td>
+                        </tr>
+                        <tr>
+                            <th>Scoring</th>
+                            <td>
+                                Area <strong>or</strong> Territory minus prisoners (Resulting winner
+                                is always the same in either case)
+                            </td>
+                            <td>Territory minus prisoners</td>
+                            <td>Area</td>
+                            <td>Territory minus prisoners</td>
+                            <td>Area</td>
+                            <td>Area</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
-    </div>
-);
+    );
+}

--- a/src/views/docs/legal.tsx
+++ b/src/views/docs/legal.tsx
@@ -17,437 +17,464 @@
 
 import * as React from "react";
 
-export const TermsOfService = () => (
-    <div className="container">
-        <div className="column well">
-            <div className="legal-paragraph">
-                <h1 style={{ textDecoration: "underline" }}>Short Unofficial Version</h1>
+export function TermsOfService(): React.ReactElement {
+    return (
+        <div className="container">
+            <div className="column well">
                 <div className="legal-paragraph">
-                    <strong>Don't sue us.</strong> This is a free service, don't sue us if we have
-                    bugs or our servers go down. Don't sue us if you managed to lose money or
-                    anything else as a result of something you perceived to be our fault (whether
-                    it's our fault or not!) Don't sue us for anything our users do. Don't sue us for
-                    any other reason either.{" "}
+                    <h1 style={{ textDecoration: "underline" }}>Short Unofficial Version</h1>
+                    <div className="legal-paragraph">
+                        <strong>Don't sue us.</strong> This is a free service, don't sue us if we
+                        have bugs or our servers go down. Don't sue us if you managed to lose money
+                        or anything else as a result of something you perceived to be our fault
+                        (whether it's our fault or not!) Don't sue us for anything our users do.
+                        Don't sue us for any other reason either.{" "}
+                    </div>
+
+                    <div className="legal-paragraph">Don't cheat, obstruct, or harass people.</div>
+
+                    <div className="legal-paragraph">
+                        We reserve the right to, at our sole discretion, delete or freeze your
+                        account and/or delete some, none, or all of the Content you've posted,
+                        generated, or otherwise stored on Online-Go.com.
+                    </div>
                 </div>
-
-                <div className="legal-paragraph">Don't cheat, obstruct, or harass people.</div>
-
+                <h1 style={{ textDecoration: "underline", marginTop: "2em" }}>
+                    Official Full Version
+                </h1>
+                In consideration of your use of the Service, you represent that you are of legal age
+                to form a binding contract.
+                <h2>Code of Conduct</h2>
                 <div className="legal-paragraph">
-                    We reserve the right to, at our sole discretion, delete or freeze your account
-                    and/or delete some, none, or all of the Content you've posted, generated, or
-                    otherwise stored on Online-Go.com.
+                    By using our service you agree not to:
+                    <ul>
+                        <li>Cheat at any games provided by Online-Go.com.</li>
+                        <li>Threaten, harass, or stalk other members.</li>
+                        <li>
+                            Upload, post, or otherwise make available any unlawful, harmful,
+                            threatening, abusive, defamatory, offensive, vulgar, obscene, libelous,
+                            hateful, or otherwise objectionable content on Online-Go.com or any
+                            service which utilizes Online-Go.com Widgets or Software.
+                        </li>
+                        <li>Impersonate any person or entity.</li>
+                        <li>
+                            Disrupt the normal flow of dialog or otherwise act in a manner that
+                            negatively affects other users' ability to communicate through or use
+                            Services provided by Online-Go.com.
+                        </li>
+                        <li>
+                            Intentionally or unintentionally violate any applicable local, state,
+                            national, or international law.
+                        </li>
+                    </ul>
                 </div>
-            </div>
-            <h1 style={{ textDecoration: "underline", marginTop: "2em" }}>Official Full Version</h1>
-            In consideration of your use of the Service, you represent that you are of legal age to
-            form a binding contract.
-            <h2>Code of Conduct</h2>
-            <div className="legal-paragraph">
-                By using our service you agree not to:
-                <ul>
-                    <li>Cheat at any games provided by Online-Go.com.</li>
-                    <li>Threaten, harass, or stalk other members.</li>
-                    <li>
-                        Upload, post, or otherwise make available any unlawful, harmful,
-                        threatening, abusive, defamatory, offensive, vulgar, obscene, libelous,
-                        hateful, or otherwise objectionable content on Online-Go.com or any service
-                        which utilizes Online-Go.com Widgets or Software.
-                    </li>
-                    <li>Impersonate any person or entity.</li>
-                    <li>
-                        Disrupt the normal flow of dialog or otherwise act in a manner that
-                        negatively affects other users' ability to communicate through or use
-                        Services provided by Online-Go.com.
-                    </li>
-                    <li>
-                        Intentionally or unintentionally violate any applicable local, state,
-                        national, or international law.
-                    </li>
-                </ul>
-            </div>
-            <h2>No Cheating or Computer Help</h2>
-            <div className="legal-paragraph">
-                You can NEVER use Go programs (Leela, Zen, etc.) or neural networks to analyze
-                current ongoing games unless specifically permitted (e.g., a computer tournament).
-                The only type of computer assistance allowed is games databases for opening lines
-                and joseki databases for corner patterns in correspondence Go. You cannot receive
-                ANY outside assistance on live or blitz Go games.
-            </div>
-            <h2>Services</h2>
-            <div className="legal-paragraph">
-                Online-Go.com provides a collection of content, resources, tools, and technologies
-                that enable users to enjoy the game of Go and interact with other users (the
-                “Service”). You understand and agree that the Service is provided "AS-IS" and that
-                Online-Go.com does not assume any liability for personal information stored through
-                our Service. You accept that the Service may include advertisements. Online-Go.com
-                reserves the right at any time and from time to time to modify or discontinue,
-                temporarily or permanently, the Service (or any part thereof) with or without
-                notice. You agree that Online-Go.com shall not be liable to you or to any third
-                party for any modification, suspension or discontinuance of the Service.
-            </div>
-            <h2>User Accounts</h2>
-            <div className="legal-paragraph">
-                You are responsible for maintaining the confidentiality of the password and account
-                and are fully responsible for all activities that occur under your password or
-                account. Online-Go.com cannot and will not be liable for any loss or damage arising
-                from your failure to protect your account.
-            </div>
-            <div className="legal-paragraph">
-                You acknowledge, consent and agree that Online-Go.com may access, preserve and
-                disclose your account information and Content if required to do so by law or in a
-                good faith belief that such access preservation or disclosure is reasonably
-                necessary to: (a) comply with legal process; (b) enforce the ToS; (c) respond to
-                claims that any Content violates the rights of third parties; (d) respond to your
-                requests for customer service; or (e) protect the rights, property or personal
-                safety of Online-Go.com, its users and the public.
-            </div>
-            <h2>Account Limitations</h2>
-            You acknowledge that Online-Go.com may establish general practices and limits concerning
-            the use of the Service. You agree that Online-Go.com has no responsibility or liability
-            for the deletion or failure to store any messages, game history, or other Content or
-            communications maintained or transmitted by the Service. You acknowledge that
-            Online-Go.com reserves the right to remove, disable, or reclaim accounts that are
-            inactive for an extended period of time. You further acknowledge that Online-Go.com
-            reserves the right to modify these general practices and limits from time to time.
-            <h2>Account Termination</h2>
-            You agree that Online-Go.com may, under certain circumstances and without prior notice,
-            immediately terminate your Online-Go.com account and access to the Service. Cause for
-            such termination shall include, but not be limited to, (a) breaches or violations of the
-            ToS or other incorporated agreements or guidelines, (b) requests by law enforcement or
-            other government agencies, (c) a request by you, (d) unexpected technical or security
-            issues or problems, (e) extended periods of inactivity, (f) engagement by you in
-            fraudulent or illegal activities, and/or (g) nonpayment of any fees owed by you in
-            connection with the Services. Termination of your Online-Go.com account includes the
-            removal of access to some or all offerings within the Service, removal of private and
-            public "profile information", and at our sole discretion, removal of messages, game
-            history, and other Content stored by Online-Go.com. Further, you agree that all
-            terminations for cause shall be made in Online-Go.com's sole discretion and that
-            Online-Go.com shall not be liable to you or any third party for any termination of your
-            account or access to the Service.
-            <h2>Content</h2>
-            <div className="legal-paragraph">
-                You acknowledge and understand that all Content (including but not limited to text,
-                photographs, and videos), whether it be publicly posted or privately transmitted, is
-                the sole responsibility of the person who created, posted, or otherwise transmitted
-                the Content. Online-Go.com does not monitor or control user created Content, and as
-                such does not guarantee the accuracy, integrity, quality, or legality of such
-                Content. By using the Service, you understand that you may unintentionally be
-                exposed to Content that is offensive, indecent, or objectionable. Under no
-                circumstances will Online-Go.com be liable in any way for any Content, including,
-                but not limited to, any errors or omissions in any Content, or any loss or damage of
-                any kind incurred as a result of the use of any Content posted, emailed,
-                transmitted, or otherwise made available by the Service.
-            </div>
-            <div className="legal-paragraph">
-                You acknowledge and understand that Online-Go.com reserves the right to move or
-                remove any content on Online-Go.com Services.
-            </div>
-            <div className="legal-paragraph">
-                Online-Go.com does not claim ownership of any Content you submit or otherwise make
-                available through the Service. However, by submitting Content to the service you
-                grant Online-Go.com the following worldwide, royalty-free, and non-exclusive
-                license: that any Content you submit or make available on or through the Service,
-                the perpetual, irrevocable, and fully sublicensable license to use, distribute,
-                reproduce, modify, adapt, publish, translate, perform, and display such Content (in
-                whole or in part) and to incorporate such Content into other works in any format or
-                medium known or later developed.
-            </div>
-            <h2>Indemnity</h2>
-            <div className="legal-paragraph">
-                You agree to indemnify and hold Online-Go.com its subsidiaries, affiliates,
-                officers, agents, employees, partners and licensors harmless from any claim or
-                demand, including reasonable attorneys' fees, made by any third party due to or
-                arising out of Content you submit, post, transmit or otherwise make available
-                through the Service, your use of the Service, your connection to the Service, your
-                violation of the ToS, or your violation of any rights of another.
-            </div>
-            <h2>Advertisements</h2>
-            <div className="legal-paragraph">
-                As consideration for your use of Online-Go.com services, you agree that
-                Online-Go.com may place various forms of advertisements throughout the site and
-                other communications. Furthermore, you agree that Online-Go.com shall not be
-                responsible or liable for any loss or damage of any sort incurred by you as a result
-                of the presence of such advertisements on Online-Go.com services or your subsequent
-                dealings with advertisers.
-            </div>
-            <h2>Links</h2>
-            <div className="legal-paragraph">
-                The Service may provide, or third parties may provide, links to other World Wide Web
-                sites or resources. Because Online-Go.com has no control over such sites and
-                resources, you acknowledge and agree that Online-Go.com is not responsible for the
-                availability of such external sites or resources, and does not endorse and is not
-                responsible or liable for any Content, advertising, products or other materials on
-                or available from such sites or resources. You further acknowledge and agree that
-                Online-Go.com shall not be responsible or liable, directly or indirectly, for any
-                damage or loss caused or alleged to be caused by or in connection with use of or
-                reliance on any such Content, goods or services available on or through any such
-                site or resource.
-            </div>
-            <h2>General Information</h2>
-            <div className="legal-paragraph">
-                The Terms of Service constitutes the entire agreement between you and Online-Go.com
-                and governs your use of the Service, superseding any prior agreements between you
-                and Online-Go.com with respect to the Service. You also may be subject to additional
-                terms and conditions that may apply when you use or purchase certain other
-                Online-Go.com services, affiliate services, third-party content or third-party
-                software. The ToS and the relationship between you and Online-Go.com shall be
-                governed by the laws of the State of North Carolina without regard to its conflict
-                of law provisions. You and Online-Go.com agree to submit to the personal and
-                exclusive jurisdiction of the courts located within the State of North Carolina. The
-                failure of Online-Go.com to exercise or enforce any right or provision of the ToS
-                shall not constitute a waiver of such right or provision. If any provision of the
-                ToS is found by a court of competent jurisdiction to be invalid, the parties
-                nevertheless agree that the court should endeavor to give effect to the parties'
-                intentions as reflected in the provision, and the other provisions of the ToS remain
-                in full force and effect. You agree that regardless of any statute or law to the
-                contrary, any claim or cause of action arising out of or related to use of the
-                Service or the ToS must be filed within one (1) year after such claim or cause of
-                action arose or be forever barred.
-            </div>
-            <h2>DISCLAIMER OF WARRANTIES</h2>
-            <div className="legal-paragraph">
-                YOU EXPRESSLY UNDERSTAND AND AGREE THAT:
-                <ol>
-                    <li>
-                        YOUR USE OF THE SERVICE IS AT YOUR SOLE RISK. THE SERVICE IS PROVIDED ON AN
-                        "AS IS" AND "AS AVAILABLE" BASIS. ONLINE-GO.COM AND ITS SUBSIDIARIES,
-                        AFFILIATES, OFFICERS, EMPLOYEES, AGENTS, PARTNERS AND LICENSORS EXPRESSLY
-                        DISCLAIM ALL WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING,
-                        BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-                        PARTICULAR PURPOSE AND NON-INFRINGEMENT.
-                    </li>
-                    <li>
-                        ONLINE-GO.COM AND ITS SUBSIDIARIES, AFFILIATES, OFFICERS, EMPLOYEES, AGENTS,
-                        PARTNERS AND LICENSORS MAKE NO WARRANTY THAT (i) THE SERVICE WILL MEET YOUR
-                        REQUIREMENTS; (ii) THE SERVICE WILL BE UNINTERRUPTED, TIMELY, SECURE OR
-                        ERROR-FREE; (iii) THE RESULTS THAT MAY BE OBTAINED FROM THE USE OF THE
-                        SERVICE WILL BE ACCURATE OR RELIABLE; (iv) THE QUALITY OF ANY PRODUCTS,
-                        SERVICES, INFORMATION OR OTHER MATERIAL PURCHASED OR OBTAINED BY YOU THROUGH
-                        THE SERVICE WILL MEET YOUR EXPECTATIONS; AND (v) ANY ERRORS IN THE SOFTWARE
-                        WILL BE CORRECTED.
-                    </li>
-                    <li>
-                        ANY MATERIAL DOWNLOADED OR OTHERWISE OBTAINED THROUGH THE USE OF THE SERVICE
-                        IS ACCESSED AT YOUR OWN DISCRETION AND RISK, AND YOU WILL BE SOLELY
-                        RESPONSIBLE FOR ANY DAMAGE TO YOUR COMPUTER SYSTEM OR LOSS OF DATA THAT
-                        RESULTS FROM THE DOWNLOAD OF ANY SUCH MATERIAL.
-                    </li>
-                    <li>
-                        NO ADVICE OR INFORMATION, WHETHER ORAL OR WRITTEN, OBTAINED BY YOU FROM
-                        ONLINE-GO.COM OR THROUGH OR FROM THE SERVICE SHALL CREATE ANY WARRANTY NOT
-                        EXPRESSLY STATED IN THE TOS.
-                    </li>
-                    <li>
-                        A SMALL PERCENTAGE OF USERS MAY EXPERIENCE EPILEPTIC SEIZURES WHEN EXPOSED
-                        TO CERTAIN LIGHT PATTERNS OR BACKGROUNDS ON A COMPUTER SCREEN OR WHILE USING
-                        THE SERVICE. CERTAIN CONDITIONS MAY INDUCE PREVIOUSLY UNDETECTED EPILEPTIC
-                        SYMPTOMS EVEN IN USERS WHO HAVE NO HISTORY OF PRIOR SEIZURES OR EPILEPSY. IF
-                        YOU, OR ANYONE IN YOUR FAMILY, HAVE AN EPILEPTIC CONDITION, CONSULT YOUR
-                        PHYSICIAN PRIOR TO USING THE SERVICE. IMMEDIATELY DISCONTINUE USE OF THE
-                        SERVICE AND CONSULT YOUR PHYSICIAN IF YOU EXPERIENCE ANY OF THE FOLLOWING
-                        SYMPTOMS WHILE USING THE SERVICE: DIZZINESS, ALTERED VISION, EYE OR MUSCLE
-                        TWITCHES, LOSS OF AWARENESS, DISORIENTATION, ANY INVOLUNTARY MOVEMENT, OR
-                        CONVULSIONS.
-                    </li>
-                </ol>
-            </div>
-            <h2>LIMITATION OF LIABILITY</h2>
-            <div className="legal-paragraph">
-                YOU EXPRESSLY UNDERSTAND AND AGREE THAT ONLINE-GO.COM AND ITS SUBSIDIARIES,
-                AFFILIATES, OFFICERS, EMPLOYEES, AGENTS, PARTNERS AND LICENSORS SHALL NOT BE LIABLE
-                TO YOU FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR EXEMPLARY
-                DAMAGES, INCLUDING, BUT NOT LIMITED TO, DAMAGES FOR LOSS OF PROFITS, GOODWILL, USE,
-                DATA OR OTHER INTANGIBLE LOSSES (EVEN IF ONLINE-GO.COM HAS BEEN ADVISED OF THE
-                POSSIBILITY OF SUCH DAMAGES), RESULTING FROM:
-                <ol>
-                    <li>THE USE OR THE INABILITY TO USE THE SERVICE.</li>
-                    <li>
-                        THE COST OF PROCUREMENT OF SUBSTITUTE GOODS AND SERVICES RESULTING FROM ANY
-                        GOODS, DATA, INFORMATION OR SERVICES PURCHASED OR OBTAINED OR MESSAGES
-                        RECEIVED OR TRANSACTIONS ENTERED INTO THROUGH OR FROM THE SERVICE.
-                    </li>
-                    <li>UNAUTHORIZED ACCESS TO OR ALTERATION OF YOUR TRANSMISSIONS OR DATA.</li>
-                    <li>STATEMENTS OR CONDUCT OF ANY THIRD PARTY ON THE SERVICE. </li>
-                    <li> ANY OTHER MATTER RELATING TO THE SERVICE.</li>
-                </ol>
-                YOU HEREBY ACKNOWLEDGE THAT THIS SECTION SHALL APPLY TO ALL CONTENTS ON ALL SERVERS
-                AND ALL SERVICES. SOME JURISDICTIONS DO NOT ALLOW THE LIMITATION OR EXCLUSION OF
-                LIABILITY FOR INCIDENTAL OR CONSEQUENTIAL DAMAGES YOU AGREE THAT IN THOSE
-                JURISDICTIONS, ONLINE-GO.COM'S LIABILITY WILL BE LIMITED TO THE EXTENT PERMITTED BY
-                LAW.
-            </div>
-            <h2>Partial Invalidity</h2>
-            If any provision of this Agreement is held to be invalid by a court of competent
-            jurisdiction, then the remaining provisions shall nevertheless remain in full force and
-            effect. Online-Go.com and the User agree to renegotiate any term held invalid and to be
-            bound by mutually agreed substitute provision.
-            <h2>Changes to the Terms of Service</h2>
-            We may revise the Terms of Service from time to time. The most current version of the
-            policy will govern our use of your information and will always be at{" "}
-            <a href="http://online-go.com/docs/terms-of-service">
-                http://online-go.com/docs/terms-of-service
-            </a>
-            . If we make a change to the Terms of Service that, in our sole discretion, is material,
-            we will notify you via an email to the email address associated with your account (if
-            one is provided and verified), or by prominently displaying a Terms of Service notice.
-            By continuing to access or use the Services after those changes become effective, you
-            agree to be bound by the revised Terms of Service.
-            <div style={{ marginTop: "2em" }}>
-                <em>Effective: Oct 30, 2012</em>
+                <h2>No Cheating or Computer Help</h2>
+                <div className="legal-paragraph">
+                    You can NEVER use Go programs (Leela, Zen, etc.) or neural networks to analyze
+                    current ongoing games unless specifically permitted (e.g., a computer
+                    tournament). The only type of computer assistance allowed is games databases for
+                    opening lines and joseki databases for corner patterns in correspondence Go. You
+                    cannot receive ANY outside assistance on live or blitz Go games.
+                </div>
+                <h2>Services</h2>
+                <div className="legal-paragraph">
+                    Online-Go.com provides a collection of content, resources, tools, and
+                    technologies that enable users to enjoy the game of Go and interact with other
+                    users (the “Service”). You understand and agree that the Service is provided
+                    "AS-IS" and that Online-Go.com does not assume any liability for personal
+                    information stored through our Service. You accept that the Service may include
+                    advertisements. Online-Go.com reserves the right at any time and from time to
+                    time to modify or discontinue, temporarily or permanently, the Service (or any
+                    part thereof) with or without notice. You agree that Online-Go.com shall not be
+                    liable to you or to any third party for any modification, suspension or
+                    discontinuance of the Service.
+                </div>
+                <h2>User Accounts</h2>
+                <div className="legal-paragraph">
+                    You are responsible for maintaining the confidentiality of the password and
+                    account and are fully responsible for all activities that occur under your
+                    password or account. Online-Go.com cannot and will not be liable for any loss or
+                    damage arising from your failure to protect your account.
+                </div>
+                <div className="legal-paragraph">
+                    You acknowledge, consent and agree that Online-Go.com may access, preserve and
+                    disclose your account information and Content if required to do so by law or in
+                    a good faith belief that such access preservation or disclosure is reasonably
+                    necessary to: (a) comply with legal process; (b) enforce the ToS; (c) respond to
+                    claims that any Content violates the rights of third parties; (d) respond to
+                    your requests for customer service; or (e) protect the rights, property or
+                    personal safety of Online-Go.com, its users and the public.
+                </div>
+                <h2>Account Limitations</h2>
+                You acknowledge that Online-Go.com may establish general practices and limits
+                concerning the use of the Service. You agree that Online-Go.com has no
+                responsibility or liability for the deletion or failure to store any messages, game
+                history, or other Content or communications maintained or transmitted by the
+                Service. You acknowledge that Online-Go.com reserves the right to remove, disable,
+                or reclaim accounts that are inactive for an extended period of time. You further
+                acknowledge that Online-Go.com reserves the right to modify these general practices
+                and limits from time to time.
+                <h2>Account Termination</h2>
+                You agree that Online-Go.com may, under certain circumstances and without prior
+                notice, immediately terminate your Online-Go.com account and access to the Service.
+                Cause for such termination shall include, but not be limited to, (a) breaches or
+                violations of the ToS or other incorporated agreements or guidelines, (b) requests
+                by law enforcement or other government agencies, (c) a request by you, (d)
+                unexpected technical or security issues or problems, (e) extended periods of
+                inactivity, (f) engagement by you in fraudulent or illegal activities, and/or (g)
+                nonpayment of any fees owed by you in connection with the Services. Termination of
+                your Online-Go.com account includes the removal of access to some or all offerings
+                within the Service, removal of private and public "profile information", and at our
+                sole discretion, removal of messages, game history, and other Content stored by
+                Online-Go.com. Further, you agree that all terminations for cause shall be made in
+                Online-Go.com's sole discretion and that Online-Go.com shall not be liable to you or
+                any third party for any termination of your account or access to the Service.
+                <h2>Content</h2>
+                <div className="legal-paragraph">
+                    You acknowledge and understand that all Content (including but not limited to
+                    text, photographs, and videos), whether it be publicly posted or privately
+                    transmitted, is the sole responsibility of the person who created, posted, or
+                    otherwise transmitted the Content. Online-Go.com does not monitor or control
+                    user created Content, and as such does not guarantee the accuracy, integrity,
+                    quality, or legality of such Content. By using the Service, you understand that
+                    you may unintentionally be exposed to Content that is offensive, indecent, or
+                    objectionable. Under no circumstances will Online-Go.com be liable in any way
+                    for any Content, including, but not limited to, any errors or omissions in any
+                    Content, or any loss or damage of any kind incurred as a result of the use of
+                    any Content posted, emailed, transmitted, or otherwise made available by the
+                    Service.
+                </div>
+                <div className="legal-paragraph">
+                    You acknowledge and understand that Online-Go.com reserves the right to move or
+                    remove any content on Online-Go.com Services.
+                </div>
+                <div className="legal-paragraph">
+                    Online-Go.com does not claim ownership of any Content you submit or otherwise
+                    make available through the Service. However, by submitting Content to the
+                    service you grant Online-Go.com the following worldwide, royalty-free, and
+                    non-exclusive license: that any Content you submit or make available on or
+                    through the Service, the perpetual, irrevocable, and fully sublicensable license
+                    to use, distribute, reproduce, modify, adapt, publish, translate, perform, and
+                    display such Content (in whole or in part) and to incorporate such Content into
+                    other works in any format or medium known or later developed.
+                </div>
+                <h2>Indemnity</h2>
+                <div className="legal-paragraph">
+                    You agree to indemnify and hold Online-Go.com its subsidiaries, affiliates,
+                    officers, agents, employees, partners and licensors harmless from any claim or
+                    demand, including reasonable attorneys' fees, made by any third party due to or
+                    arising out of Content you submit, post, transmit or otherwise make available
+                    through the Service, your use of the Service, your connection to the Service,
+                    your violation of the ToS, or your violation of any rights of another.
+                </div>
+                <h2>Advertisements</h2>
+                <div className="legal-paragraph">
+                    As consideration for your use of Online-Go.com services, you agree that
+                    Online-Go.com may place various forms of advertisements throughout the site and
+                    other communications. Furthermore, you agree that Online-Go.com shall not be
+                    responsible or liable for any loss or damage of any sort incurred by you as a
+                    result of the presence of such advertisements on Online-Go.com services or your
+                    subsequent dealings with advertisers.
+                </div>
+                <h2>Links</h2>
+                <div className="legal-paragraph">
+                    The Service may provide, or third parties may provide, links to other World Wide
+                    Web sites or resources. Because Online-Go.com has no control over such sites and
+                    resources, you acknowledge and agree that Online-Go.com is not responsible for
+                    the availability of such external sites or resources, and does not endorse and
+                    is not responsible or liable for any Content, advertising, products or other
+                    materials on or available from such sites or resources. You further acknowledge
+                    and agree that Online-Go.com shall not be responsible or liable, directly or
+                    indirectly, for any damage or loss caused or alleged to be caused by or in
+                    connection with use of or reliance on any such Content, goods or services
+                    available on or through any such site or resource.
+                </div>
+                <h2>General Information</h2>
+                <div className="legal-paragraph">
+                    The Terms of Service constitutes the entire agreement between you and
+                    Online-Go.com and governs your use of the Service, superseding any prior
+                    agreements between you and Online-Go.com with respect to the Service. You also
+                    may be subject to additional terms and conditions that may apply when you use or
+                    purchase certain other Online-Go.com services, affiliate services, third-party
+                    content or third-party software. The ToS and the relationship between you and
+                    Online-Go.com shall be governed by the laws of the State of North Carolina
+                    without regard to its conflict of law provisions. You and Online-Go.com agree to
+                    submit to the personal and exclusive jurisdiction of the courts located within
+                    the State of North Carolina. The failure of Online-Go.com to exercise or enforce
+                    any right or provision of the ToS shall not constitute a waiver of such right or
+                    provision. If any provision of the ToS is found by a court of competent
+                    jurisdiction to be invalid, the parties nevertheless agree that the court should
+                    endeavor to give effect to the parties' intentions as reflected in the
+                    provision, and the other provisions of the ToS remain in full force and effect.
+                    You agree that regardless of any statute or law to the contrary, any claim or
+                    cause of action arising out of or related to use of the Service or the ToS must
+                    be filed within one (1) year after such claim or cause of action arose or be
+                    forever barred.
+                </div>
+                <h2>DISCLAIMER OF WARRANTIES</h2>
+                <div className="legal-paragraph">
+                    YOU EXPRESSLY UNDERSTAND AND AGREE THAT:
+                    <ol>
+                        <li>
+                            YOUR USE OF THE SERVICE IS AT YOUR SOLE RISK. THE SERVICE IS PROVIDED ON
+                            AN "AS IS" AND "AS AVAILABLE" BASIS. ONLINE-GO.COM AND ITS SUBSIDIARIES,
+                            AFFILIATES, OFFICERS, EMPLOYEES, AGENTS, PARTNERS AND LICENSORS
+                            EXPRESSLY DISCLAIM ALL WARRANTIES OF ANY KIND, WHETHER EXPRESS OR
+                            IMPLIED, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF
+                            MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+                        </li>
+                        <li>
+                            ONLINE-GO.COM AND ITS SUBSIDIARIES, AFFILIATES, OFFICERS, EMPLOYEES,
+                            AGENTS, PARTNERS AND LICENSORS MAKE NO WARRANTY THAT (i) THE SERVICE
+                            WILL MEET YOUR REQUIREMENTS; (ii) THE SERVICE WILL BE UNINTERRUPTED,
+                            TIMELY, SECURE OR ERROR-FREE; (iii) THE RESULTS THAT MAY BE OBTAINED
+                            FROM THE USE OF THE SERVICE WILL BE ACCURATE OR RELIABLE; (iv) THE
+                            QUALITY OF ANY PRODUCTS, SERVICES, INFORMATION OR OTHER MATERIAL
+                            PURCHASED OR OBTAINED BY YOU THROUGH THE SERVICE WILL MEET YOUR
+                            EXPECTATIONS; AND (v) ANY ERRORS IN THE SOFTWARE WILL BE CORRECTED.
+                        </li>
+                        <li>
+                            ANY MATERIAL DOWNLOADED OR OTHERWISE OBTAINED THROUGH THE USE OF THE
+                            SERVICE IS ACCESSED AT YOUR OWN DISCRETION AND RISK, AND YOU WILL BE
+                            SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR COMPUTER SYSTEM OR LOSS OF
+                            DATA THAT RESULTS FROM THE DOWNLOAD OF ANY SUCH MATERIAL.
+                        </li>
+                        <li>
+                            NO ADVICE OR INFORMATION, WHETHER ORAL OR WRITTEN, OBTAINED BY YOU FROM
+                            ONLINE-GO.COM OR THROUGH OR FROM THE SERVICE SHALL CREATE ANY WARRANTY
+                            NOT EXPRESSLY STATED IN THE TOS.
+                        </li>
+                        <li>
+                            A SMALL PERCENTAGE OF USERS MAY EXPERIENCE EPILEPTIC SEIZURES WHEN
+                            EXPOSED TO CERTAIN LIGHT PATTERNS OR BACKGROUNDS ON A COMPUTER SCREEN OR
+                            WHILE USING THE SERVICE. CERTAIN CONDITIONS MAY INDUCE PREVIOUSLY
+                            UNDETECTED EPILEPTIC SYMPTOMS EVEN IN USERS WHO HAVE NO HISTORY OF PRIOR
+                            SEIZURES OR EPILEPSY. IF YOU, OR ANYONE IN YOUR FAMILY, HAVE AN
+                            EPILEPTIC CONDITION, CONSULT YOUR PHYSICIAN PRIOR TO USING THE SERVICE.
+                            IMMEDIATELY DISCONTINUE USE OF THE SERVICE AND CONSULT YOUR PHYSICIAN IF
+                            YOU EXPERIENCE ANY OF THE FOLLOWING SYMPTOMS WHILE USING THE SERVICE:
+                            DIZZINESS, ALTERED VISION, EYE OR MUSCLE TWITCHES, LOSS OF AWARENESS,
+                            DISORIENTATION, ANY INVOLUNTARY MOVEMENT, OR CONVULSIONS.
+                        </li>
+                    </ol>
+                </div>
+                <h2>LIMITATION OF LIABILITY</h2>
+                <div className="legal-paragraph">
+                    YOU EXPRESSLY UNDERSTAND AND AGREE THAT ONLINE-GO.COM AND ITS SUBSIDIARIES,
+                    AFFILIATES, OFFICERS, EMPLOYEES, AGENTS, PARTNERS AND LICENSORS SHALL NOT BE
+                    LIABLE TO YOU FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR
+                    EXEMPLARY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DAMAGES FOR LOSS OF PROFITS,
+                    GOODWILL, USE, DATA OR OTHER INTANGIBLE LOSSES (EVEN IF ONLINE-GO.COM HAS BEEN
+                    ADVISED OF THE POSSIBILITY OF SUCH DAMAGES), RESULTING FROM:
+                    <ol>
+                        <li>THE USE OR THE INABILITY TO USE THE SERVICE.</li>
+                        <li>
+                            THE COST OF PROCUREMENT OF SUBSTITUTE GOODS AND SERVICES RESULTING FROM
+                            ANY GOODS, DATA, INFORMATION OR SERVICES PURCHASED OR OBTAINED OR
+                            MESSAGES RECEIVED OR TRANSACTIONS ENTERED INTO THROUGH OR FROM THE
+                            SERVICE.
+                        </li>
+                        <li>UNAUTHORIZED ACCESS TO OR ALTERATION OF YOUR TRANSMISSIONS OR DATA.</li>
+                        <li>STATEMENTS OR CONDUCT OF ANY THIRD PARTY ON THE SERVICE. </li>
+                        <li> ANY OTHER MATTER RELATING TO THE SERVICE.</li>
+                    </ol>
+                    YOU HEREBY ACKNOWLEDGE THAT THIS SECTION SHALL APPLY TO ALL CONTENTS ON ALL
+                    SERVERS AND ALL SERVICES. SOME JURISDICTIONS DO NOT ALLOW THE LIMITATION OR
+                    EXCLUSION OF LIABILITY FOR INCIDENTAL OR CONSEQUENTIAL DAMAGES YOU AGREE THAT IN
+                    THOSE JURISDICTIONS, ONLINE-GO.COM'S LIABILITY WILL BE LIMITED TO THE EXTENT
+                    PERMITTED BY LAW.
+                </div>
+                <h2>Partial Invalidity</h2>
+                If any provision of this Agreement is held to be invalid by a court of competent
+                jurisdiction, then the remaining provisions shall nevertheless remain in full force
+                and effect. Online-Go.com and the User agree to renegotiate any term held invalid
+                and to be bound by mutually agreed substitute provision.
+                <h2>Changes to the Terms of Service</h2>
+                We may revise the Terms of Service from time to time. The most current version of
+                the policy will govern our use of your information and will always be at{" "}
+                <a href="http://online-go.com/docs/terms-of-service">
+                    http://online-go.com/docs/terms-of-service
+                </a>
+                . If we make a change to the Terms of Service that, in our sole discretion, is
+                material, we will notify you via an email to the email address associated with your
+                account (if one is provided and verified), or by prominently displaying a Terms of
+                Service notice. By continuing to access or use the Services after those changes
+                become effective, you agree to be bound by the revised Terms of Service.
+                <div style={{ marginTop: "2em" }}>
+                    <em>Effective: Oct 30, 2012</em>
+                </div>
             </div>
         </div>
-    </div>
-);
+    );
+}
 
-export const PrivacyPolicy = () => (
-    <div className="container">
-        <div className="column well">
-            <div className="legal-paragraph">
-                <h1 style={{ textDecoration: "underline" }}>Short Version</h1>
-                <strong>Online-Go.com will not sell your private information to anyone.</strong> Nor
-                will we share your private information with anyone, except under obvious scenarios
-                detailed in the full privacy policy (such as we are required to do so by law,
-                etc...) If you provide us with additional information for your public profile, then
-                we will make that information available on our website (ie on your profile page),
-                search engines (so people can search for your name for example), and other media.
-            </div>
-            <h1 style={{ textDecoration: "underline", marginTop: "2em" }}>Official Full Version</h1>
-            <h2>Online-Go.com Privacy Policy</h2>
-            <div className="legal-paragraph">
-                This Privacy Policy describes how and when Online-Go.com collects, uses and shares
-                your information when you use our Services. Online-Go.com receives your information
-                through our various websites, APIs, applications, emails, and other electronic means
-                (the "Services" or "Online-Go.com"). For example, you send us information when you
-                use Online-Go.com from our website, access Online-Go.com from an application on your
-                smartphone or tablet, send us emails, or use embedded game boards on other websites
-                or applications. When using any of our Services you consent to the collection,
-                transfer, manipulation, storage, disclosure and other uses of your information as
-                described in this Privacy Policy. Irrespective of which country you reside in or
-                supply information from, you authorize Online-Go.com to use your information in the
-                United States and any other country where Online-Go.com operates.
-            </div>
-            <div className="legal-paragraph">
-                If you have any questions or comments about this Privacy Policy, please contact us
-                at <a href="privacy@online-go.com">privacy@online-go.com</a>
-            </div>
-            <h2>Information Collection and Use</h2>
-            <h5>Information Collected Upon Registration:</h5>
-            When you create or reconfigure a Online-Go.com account, or sign in via a 3rd party
-            authentication service (such as Google or Facebook), you provide some profile
-            information, such as your username, password, and email address. Your username is listed
-            publicly on our Services, including your profile page and in search results.
-            <h5>Additional Information:</h5>
-            <div className="legal-paragraph">
-                You may provide us with profile information to make public, such as your real name,
-                a short biography, location information, pictures, and associations to other players
-                ("Friends"). We may make some or all of your additional information available on our
-                website (under your profile, user badges, or other places). We may also use your
-                additional information to help others find your account. If you email us, we may
-                keep your message, email address and contact information to respond to your request.
-                If you connect your Online-Go.com account to another service, such as Google or
-                Facebook, the other service may send us your registration or profile information on
-                that service and other information that you authorize. Providing the additional
-                information described in this section is entirely optional.
-            </div>
-            <h5>Cookies:</h5> Like many websites we use cookies to maintain session information as a
-            means to persist login state and to preserve some settings for your convenience. Most
-            Internet browsers automatically accept cookies. All modern internet browsers allow you
-            to disable cookies by changing its settings, however some of our Services will not
-            function properly if you do this.
-            <h5>Log Data:</h5> Our servers may record information ("Log Data") created by your use
-            of our Services. Log Data may include information such as your IP address, browser type,
-            operating system, the referring web page, pages visited, location, device and
-            application ids, service provider, mobile carrier, search terms, and cookie information.
-            Log data is usually recorded when you interact with our Services, for example when you
-            visit our website, play a game, sign in, interact with our email notifications, or visit
-            a third-party site that includes an embedded game board or other widget we provide.
-            <h5>Third-Party Service Providers:</h5> Online-Go.com uses a variety of third-party
-            services to help provide our Services, such as data centers, email services, analytics
-            services, polling services, and others. These third-party service providers may collect
-            information may collect information sent by your browser as part of a web page request,
-            such as cookies, your IP address, browser type, operating system, referring web page,
-            search terms, and other information.
-            <h3>Deleting your Information</h3>
-            Your personal information is strictly optional and may at any point be removed by
-            editing your profile and removing it. You may also delete all of your information by
-            clicking the 'Delete account' button found under your Account Settings.
-            <h3>Information Sharing and Disclosure</h3>
-            <div className="legal-paragraph">
-                We do not disclose your profile information except in the limited circumstances
-                described here.
-            </div>
-            <div className="legal-paragraph">
-                <h5>Your Consent:</h5> We may share or disclose your information at your direction,
-                such as when you authorize a third-party web client or application to access your
+export function PrivacyPolicy(): React.ReactElement {
+    return (
+        <div className="container">
+            <div className="column well">
+                <div className="legal-paragraph">
+                    <h1 style={{ textDecoration: "underline" }}>Short Version</h1>
+                    <strong>
+                        Online-Go.com will not sell your private information to anyone.
+                    </strong>{" "}
+                    Nor will we share your private information with anyone, except under obvious
+                    scenarios detailed in the full privacy policy (such as we are required to do so
+                    by law, etc...) If you provide us with additional information for your public
+                    profile, then we will make that information available on our website (ie on your
+                    profile page), search engines (so people can search for your name for example),
+                    and other media.
+                </div>
+                <h1 style={{ textDecoration: "underline", marginTop: "2em" }}>
+                    Official Full Version
+                </h1>
+                <h2>Online-Go.com Privacy Policy</h2>
+                <div className="legal-paragraph">
+                    This Privacy Policy describes how and when Online-Go.com collects, uses and
+                    shares your information when you use our Services. Online-Go.com receives your
+                    information through our various websites, APIs, applications, emails, and other
+                    electronic means (the "Services" or "Online-Go.com"). For example, you send us
+                    information when you use Online-Go.com from our website, access Online-Go.com
+                    from an application on your smartphone or tablet, send us emails, or use
+                    embedded game boards on other websites or applications. When using any of our
+                    Services you consent to the collection, transfer, manipulation, storage,
+                    disclosure and other uses of your information as described in this Privacy
+                    Policy. Irrespective of which country you reside in or supply information from,
+                    you authorize Online-Go.com to use your information in the United States and any
+                    other country where Online-Go.com operates.
+                </div>
+                <div className="legal-paragraph">
+                    If you have any questions or comments about this Privacy Policy, please contact
+                    us at <a href="privacy@online-go.com">privacy@online-go.com</a>
+                </div>
+                <h2>Information Collection and Use</h2>
+                <h5>Information Collected Upon Registration:</h5>
+                When you create or reconfigure a Online-Go.com account, or sign in via a 3rd party
+                authentication service (such as Google or Facebook), you provide some profile
+                information, such as your username, password, and email address. Your username is
+                listed publicly on our Services, including your profile page and in search results.
+                <h5>Additional Information:</h5>
+                <div className="legal-paragraph">
+                    You may provide us with profile information to make public, such as your real
+                    name, a short biography, location information, pictures, and associations to
+                    other players ("Friends"). We may make some or all of your additional
+                    information available on our website (under your profile, user badges, or other
+                    places). We may also use your additional information to help others find your
+                    account. If you email us, we may keep your message, email address and contact
+                    information to respond to your request. If you connect your Online-Go.com
+                    account to another service, such as Google or Facebook, the other service may
+                    send us your registration or profile information on that service and other
+                    information that you authorize. Providing the additional information described
+                    in this section is entirely optional.
+                </div>
+                <h5>Cookies:</h5> Like many websites we use cookies to maintain session information
+                as a means to persist login state and to preserve some settings for your
+                convenience. Most Internet browsers automatically accept cookies. All modern
+                internet browsers allow you to disable cookies by changing its settings, however
+                some of our Services will not function properly if you do this.
+                <h5>Log Data:</h5> Our servers may record information ("Log Data") created by your
+                use of our Services. Log Data may include information such as your IP address,
+                browser type, operating system, the referring web page, pages visited, location,
+                device and application ids, service provider, mobile carrier, search terms, and
+                cookie information. Log data is usually recorded when you interact with our
+                Services, for example when you visit our website, play a game, sign in, interact
+                with our email notifications, or visit a third-party site that includes an embedded
+                game board or other widget we provide.
+                <h5>Third-Party Service Providers:</h5> Online-Go.com uses a variety of third-party
+                services to help provide our Services, such as data centers, email services,
+                analytics services, polling services, and others. These third-party service
+                providers may collect information may collect information sent by your browser as
+                part of a web page request, such as cookies, your IP address, browser type,
+                operating system, referring web page, search terms, and other information.
+                <h3>Deleting your Information</h3>
+                Your personal information is strictly optional and may at any point be removed by
+                editing your profile and removing it. You may also delete all of your information by
+                clicking the 'Delete account' button found under your Account Settings.
+                <h3>Information Sharing and Disclosure</h3>
+                <div className="legal-paragraph">
+                    We do not disclose your profile information except in the limited circumstances
+                    described here.
+                </div>
+                <div className="legal-paragraph">
+                    <h5>Your Consent:</h5> We may share or disclose your information at your
+                    direction, such as when you authorize a third-party web client or application to
+                    access your Online-Go.com account.
+                </div>
+                <div className="legal-paragraph">
+                    <h5>Law and Harm:</h5> Notwithstanding anything to the contrary in this Policy,
+                    we may preserve or disclose your information if we believe that it is reasonably
+                    necessary to comply with a law, regulation or legal request; to protect the
+                    safety of any person; to address fraud, security or technical issues. However,
+                    nothing in this Privacy Policy is intended to limit any legal defenses or
+                    objections that you may have to a third party's, including a government's,
+                    request to disclose your information.
+                </div>
+                <div className="legal-paragraph">
+                    <h5>Non-Private or Non-Personal Information:</h5> We may share or disclose your
+                    non-private, aggregated or otherwise non-personal information, such as your
+                    public user profile information, game information (both ongoing and historical),
+                    friends, public and game chats, and forum posts.
+                </div>
+                <h3>Modifying Your Profile Information</h3>
+                If you are a registered user of our Services, we provide you with tools and account
+                settings to access or modify the personal information associated with your
                 Online-Go.com account.
-            </div>
-            <div className="legal-paragraph">
-                <h5>Law and Harm:</h5> Notwithstanding anything to the contrary in this Policy, we
-                may preserve or disclose your information if we believe that it is reasonably
-                necessary to comply with a law, regulation or legal request; to protect the safety
-                of any person; to address fraud, security or technical issues. However, nothing in
-                this Privacy Policy is intended to limit any legal defenses or objections that you
-                may have to a third party's, including a government's, request to disclose your
-                information.
-            </div>
-            <div className="legal-paragraph">
-                <h5>Non-Private or Non-Personal Information:</h5> We may share or disclose your
-                non-private, aggregated or otherwise non-personal information, such as your public
-                user profile information, game information (both ongoing and historical), friends,
-                public and game chats, and forum posts.
-            </div>
-            <h3>Modifying Your Profile Information</h3>
-            If you are a registered user of our Services, we provide you with tools and account
-            settings to access or modify the personal information associated with your Online-Go.com
-            account.
-            <h3>Our Policy Towards Children</h3>
-            Our Services are not directed to persons under 13. If you become aware that your child
-            has provided us with profile information without your consent, please contact us at{" "}
-            <a href="mailto:privacy@online-go.com">privacy@online-go.com</a>. We do not knowingly
-            collect personally identifiable information from children under 13. If we become aware
-            that a child under 13 has provided us with personally identifiable information, we take
-            steps to remove such information and terminate the child's account.
-            <h3>Changes to this Policy</h3>
-            We may revise this Privacy Policy from time to time. The most current version of the
-            policy will govern our use of your information and will always be at{" "}
-            <a href="http://online-go.com/docs/privacy-policy">
-                http://online-go.com/docs/privacy-policy
-            </a>
-            . If we make a change to this policy that, in our sole discretion, is material, we will
-            notify you via an email to the email address associated with your account (if one is
-            provided and verified), or by prominently displaying a Privacy Update notice. By
-            continuing to access or use the Services after those changes become effective, you agree
-            to be bound by the revised Privacy Policy.
-            <div style={{ marginTop: "2em" }}>
-                <em>Effective: Sep 25, 2021</em>
+                <h3>Our Policy Towards Children</h3>
+                Our Services are not directed to persons under 13. If you become aware that your
+                child has provided us with profile information without your consent, please contact
+                us at <a href="mailto:privacy@online-go.com">privacy@online-go.com</a>. We do not
+                knowingly collect personally identifiable information from children under 13. If we
+                become aware that a child under 13 has provided us with personally identifiable
+                information, we take steps to remove such information and terminate the child's
+                account.
+                <h3>Changes to this Policy</h3>
+                We may revise this Privacy Policy from time to time. The most current version of the
+                policy will govern our use of your information and will always be at{" "}
+                <a href="http://online-go.com/docs/privacy-policy">
+                    http://online-go.com/docs/privacy-policy
+                </a>
+                . If we make a change to this policy that, in our sole discretion, is material, we
+                will notify you via an email to the email address associated with your account (if
+                one is provided and verified), or by prominently displaying a Privacy Update notice.
+                By continuing to access or use the Services after those changes become effective,
+                you agree to be bound by the revised Privacy Policy.
+                <div style={{ marginTop: "2em" }}>
+                    <em>Effective: Sep 25, 2021</em>
+                </div>
             </div>
         </div>
-    </div>
-);
-export const ContactInformation = () => (
-    <div style={{ textAlign: "center", padding: "4em" }}>
-        <h3>
-            For <span style={{ fontWeight: "bold", textDecoration: "underline" }}>non-support</span>{" "}
-            related contact, please drop us an email at:
-        </h3>
-        <h4>
-            <a href="mailto:contact@online-go.com">contact@online-go.com</a>
-        </h4>
-        <br />
-        For support, please use the forums:{" "}
-        <a href="http://forums.online-go.com">http://forums.online-go.com</a>.
-    </div>
-);
-export const RefundPolicy = () => (
-    <div className="container">
-        <div className="column well">
-            <h1>Refund Policy</h1>
+    );
+}
 
-            <div className="legal-paragraph">
-                Supporter account subscriptions may be canceled at any time. Refunds for the last
-                payment will be given upon request. All requests must be received within 30 days of
-                the last payment.
+export function ContactInformation(): React.ReactElement {
+    return (
+        <div style={{ textAlign: "center", padding: "4em" }}>
+            <h3>
+                For{" "}
+                <span style={{ fontWeight: "bold", textDecoration: "underline" }}>non-support</span>{" "}
+                related contact, please drop us an email at:
+            </h3>
+            <h4>
+                <a href="mailto:contact@online-go.com">contact@online-go.com</a>
+            </h4>
+            <br />
+            For support, please use the forums:{" "}
+            <a href="http://forums.online-go.com">http://forums.online-go.com</a>.
+        </div>
+    );
+}
+
+export function RefundPolicy(): React.ReactElement {
+    return (
+        <div className="container">
+            <div className="column well">
+                <h1>Refund Policy</h1>
+
+                <div className="legal-paragraph">
+                    Supporter account subscriptions may be canceled at any time. Refunds for the
+                    last payment will be given upon request. All requests must be received within 30
+                    days of the last payment.
+                </div>
             </div>
         </div>
-    </div>
-);
+    );
+}


### PR DESCRIPTION
This PR converts exported lambda declarations to regular function declarations to improve code consistency.

Changes:
- Convert exported lambda declarations to regular function declarations
- Add proper return types for React components
- Fix formatting and indentation
- Add proper closing braces and parentheses
- Run prettier and linter to ensure consistent formatting

All changes have been tested and the project builds successfully.